### PR TITLE
Only copy JDK files that contain Classpath exception line

### DIFF
--- a/make/langtools/netbeans/nb-javac/build.xml
+++ b/make/langtools/netbeans/nb-javac/build.xml
@@ -113,7 +113,7 @@
         <available file="../../../../../nbbuild/netbeans/java/modules/ext" type="dir" property="modules.ext.exists"/>
     </target>
 
-    <target name="propertiesparser" depends="init">
+    <target name="propertiesparser" depends="jackpot">
         <mkdir dir="${root}/lib/propertiesparser"/>
         <javac destdir="${root}/lib/propertiesparser" source="1.8" target="1.8" release="8" debug="true" srcdir="${jdk.repo}/make/langtools/tools/">
             <include name="propertiesparser/**/*.java"/>
@@ -124,13 +124,13 @@
         </path>
         <java failonerror="true" classpathref="propertiesparser" classname="propertiesparser.PropertiesParser">
             <arg value="-compile"/>
-            <arg value="${jdk.repo}/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties"/>
-            <arg value="${jdk.repo}/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/"/>
+            <arg value="${src.dir}/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties"/>
+            <arg value="${src.dir}/jdk.compiler/share/classes/com/sun/tools/javac/resources/"/>
         </java>
         <java failonerror="true" classpathref="propertiesparser" classname="propertiesparser.PropertiesParser">
             <arg value="-compile"/>
-            <arg value="${jdk.repo}/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties"/>
-            <arg value="${jdk.repo}/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/"/>
+            <arg value="${src.dir}/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties"/>
+            <arg value="${src.dir}/jdk.compiler/share/classes/com/sun/tools/javac/resources/"/>
         </java>
     </target>
 
@@ -143,11 +143,18 @@
         <mkdir dir="${src.dir}"/>
         <copy todir="${src.dir}">
             <fileset dir="${jdk.repo}/src/">
-                <include name="java.compiler/**"/>
-                <include name="jdk.compiler/**"/>
-                <include name="jdk.jdeps/share/classes/module-info.java"/>
-                <include name="jdk.jdeps/share/classes/com/sun/tools/classfile/**"/>
-                <include name="jdk.jdeps/share/classes/com/sun/tools/javap/**"/>
+                <selector>
+                    <and>
+                        <or>
+                            <filename name="java.compiler/**"/>
+                            <filename name="jdk.compiler/**"/>
+                            <filename name="jdk.jdeps/share/classes/module-info.java"/>
+                            <filename name="jdk.jdeps/share/classes/com/sun/tools/classfile/**"/>
+                            <filename name="jdk.jdeps/share/classes/com/sun/tools/javap/**"/>
+                        </or>
+                        <containsregexp expression="particular *file *as *subject *to *the.*Classpath.*exception"/>
+                    </and>
+                </selector>
             </fileset>
         </copy>
         <java fork="true" failonerror="true" classpath="${tools.dir}/jackpot.jar" classname="org.netbeans.modules.jackpot30.cmdline.Main">


### PR DESCRIPTION
One of the important tasks for using [nb-javac in Apache NetBeans](https://cwiki.apache.org/confluence/display/NETBEANS/Overview%3A+nb-javac) also mentioned in [LEGAL-563](https://issues.apache.org/jira/browse/LEGAL-563) is to make sure only files covered by _classpath exception_ are used in `nb-javac` library.

This PR achieves that by defining an Ant `selector` based on presence of the typical _Classpath exception_ line:
```xml
                <selector>
                    <and>
                        <or>
                            <filename name="java.compiler/**"/>
                            <filename name="jdk.compiler/**"/>
                            <filename name="jdk.jdeps/share/classes/module-info.java"/>
                            <filename name="jdk.jdeps/share/classes/com/sun/tools/classfile/**"/>
                            <filename name="jdk.jdeps/share/classes/com/sun/tools/javap/**"/>
                        </or>
                        <containsregexp expression="particular *file *as *subject *to *the.*Classpath.*exception"/>
                    </and>
                </selector>
```
with this check it shall be guaranteed only _GPLv2+ClasspathException_ files from the [JDK repository](https://github.com/openjdk/jdk) are used.