### PR TITLE
Testing on JDK17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/setup-java@v2
         with:
             distribution: 'zulu'
-            java-version: 17.0.0+35-ea
-      - name: Do build
-        run: JAVA_HOME8=`cat jdk8` JAVA_HOME17=$JAVA_HOME bash build.sh
+            java-version: 17.0.0
+      - name: Build on JDK17
+        run: ant -f make/langtools/netbeans/nb-javac jar
+      - name: Test on JDK8
+        run: JAVA_HOME=`cat jdk8` ant -f make/langtools/netbeans/nb-javac test
+      - name: Test on JDK17
+        run: ant -f make/langtools/netbeans/nb-javac test

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ if ! [ -f $JAVA_HOME17/jmods/java.base.jmod ]; then
 fi
 
 export JAVA_HOME=$JAVA_HOME17
-ant -d $ANT_ARGS_EXTRA -f make/langtools/netbeans/nb-javac clean jar
+ant -d $ANT_ARGS_EXTRA -f make/langtools/netbeans/nb-javac clean jar test
 
 
 export JAVA_HOME=$JAVA_HOME8

--- a/make/langtools/netbeans/nb-javac/nbproject/build-impl.xml
+++ b/make/langtools/netbeans/nb-javac/nbproject/build-impl.xml
@@ -46,8 +46,8 @@ is divided into following sections:
         <property file="${user.properties.file}"/>
         <!-- The two properties below are usually overridden -->
         <!-- by the active platform. Just a fallback. -->
-        <property name="default.javac.source" value="1.6"/>
-        <property name="default.javac.target" value="1.6"/>
+        <property name="default.javac.source" value="1.8"/>
+        <property name="default.javac.target" value="1.8"/>
     </target>
     <target depends="-pre-init,-init-private,-init-user" name="-init-project">
         <property file="nbproject/configs/${config}.properties"/>
@@ -202,7 +202,8 @@ is divided into following sections:
                 <isfalse value="${javadoc.preview}"/>
             </and>
         </condition>
-        <property name="run.jvmargs" value=""/>
+        <available classname="java.lang.Module" property="run.jvmargs" value="${run.jvmargs.jdk11}"/>
+        <property name="run.jvmargs" value="${run.jvmargs.jdk8}"/>
         <property name="run.jvmargs.ide" value=""/>
         <property name="javac.compilerargs" value=""/>
         <property name="work.dir" value="${basedir}"/>

--- a/make/langtools/netbeans/nb-javac/nbproject/build-impl.xml
+++ b/make/langtools/netbeans/nb-javac/nbproject/build-impl.xml
@@ -202,7 +202,7 @@ is divided into following sections:
                 <isfalse value="${javadoc.preview}"/>
             </and>
         </condition>
-        <available classname="java.lang.Module" property="run.jvmargs" value="${run.jvmargs.jdk11}"/>
+        <available classname="java.lang.Module" property="run.jvmargs" value="${run.jvmargs.jdk17}"/>
         <property name="run.jvmargs" value="${run.jvmargs.jdk8}"/>
         <property name="run.jvmargs.ide" value=""/>
         <property name="javac.compilerargs" value=""/>

--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -109,6 +109,7 @@ javadoc.windowtitle=
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}:\
+    ${dist.dir}/nb-javac-${nb-javac-ver}-impl.jar:\
     ${build.dir}/lib/junit-4.12.jar:\
     ${build.dir}/lib/hamcrest-core-1.3.jar
 debug.classpath=${run.classpath}

--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -21,7 +21,8 @@ javadoc.splitindex=true
 debug.jvmargs=-Ddebug=false
 run.jvmargs=\
     ${debug.jvmargs} \
-    -Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-api.jar:-Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-impl.jar
+    --limit-modules java.base,java.xml
+#    -Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-api.jar:-Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-impl.jar
 run.modulepath=\
     ${javac.modulepath}:\
     ${build.classes.dir}

--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -21,7 +21,7 @@ javadoc.splitindex=true
 debug.jvmargs=-Ddebug=false
 run.jvmargs=\
     ${debug.jvmargs} \
-    --limit-modules java.base,java.xml
+    --limit-modules java.base,java.xml,jdk.zipfs
 #    -Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-api.jar:-Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-impl.jar
 run.modulepath=\
     ${javac.modulepath}:\

--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -19,10 +19,12 @@ jlink.launcher.name=nb-javac
 jnlp.offline-allowed=false
 javadoc.splitindex=true
 debug.jvmargs=-Ddebug=false
-run.jvmargs=\
+run.jvmargs.jdk11=\
     ${debug.jvmargs} \
     --limit-modules java.base,java.xml,jdk.zipfs
-#    -Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-api.jar:-Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-impl.jar
+run.jvmargs.jdk8=\
+    ${debug.jvmargs} \
+    -Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-api.jar:-Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-impl.jar
 run.modulepath=\
     ${javac.modulepath}:\
     ${build.classes.dir}

--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -19,9 +19,10 @@ jlink.launcher.name=nb-javac
 jnlp.offline-allowed=false
 javadoc.splitindex=true
 debug.jvmargs=-Ddebug=false
-run.jvmargs.jdk11=\
+run.jvmargs.jdk17=\
     ${debug.jvmargs} \
-    --limit-modules java.base,java.xml,jdk.zipfs
+    --limit-modules java.base,java.xml,jdk.zipfs \
+    --add-exports=java.base/sun.reflect.annotation=ALL-UNNAMED
 run.jvmargs.jdk8=\
     ${debug.jvmargs} \
     -Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-api.jar:-Xbootclasspath/p:${dist.dir}/nb-javac-${nb-javac-ver}-impl.jar

--- a/make/langtools/netbeans/nb-javac/test/com/sun/tools/javac/comp/AttrTest.java
+++ b/make/langtools/netbeans/nb-javac/test/com/sun/tools/javac/comp/AttrTest.java
@@ -25,22 +25,14 @@
 package com.sun.tools.javac.comp;
 
 import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.LiteralTree;
-import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
-import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
-import com.sun.source.util.TreeScanner;
 import com.sun.source.util.Trees;
-import com.sun.tools.javac.api.JavacScope;
 import com.sun.tools.javac.api.JavacTaskImpl;
-import com.sun.tools.javac.api.JavacTrees;
-import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCLambda;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -66,10 +58,7 @@ import javax.tools.JavaFileObject.Kind;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
 import junit.framework.TestCase;
-import org.junit.Ignore;
 
 /**
  *
@@ -146,11 +135,18 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:64-72:compiler.err.type.error")), diagnostics);
+    }
+
+    private void collectErrors(DiagnosticCollector<JavaFileObject> dc, Set<String> diagnostics) {
+        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
+            if (d.getSource() == null) {
+                continue;
+            }
+            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
+        }
     }
     
     public void testErrorReturnType2() throws IOException {
@@ -167,9 +163,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:68-68:compiler.err.expected")), diagnostics);
     }
@@ -188,9 +182,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:64-73:compiler.err.cant.resolve.location.args")), diagnostics);
     }
@@ -209,9 +201,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:90-94:compiler.err.type.error")), diagnostics);
     }
@@ -229,9 +219,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.<String>asList("/Use.java:47-52:compiler.err.cant.resolve.location")), diagnostics);
     }
@@ -250,9 +238,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:64-71:compiler.err.type.error")), diagnostics);
     }
@@ -271,9 +257,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:64-73:compiler.err.cant.resolve.location")), diagnostics);
     }
@@ -291,9 +275,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:64-69:compiler.err.cant.resolve.location")), diagnostics);
     }
@@ -311,9 +293,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:93-104:compiler.err.cant.apply.diamond.1")), diagnostics);
     }
@@ -331,10 +311,7 @@ public class AttrTest extends TestCase {
         ct.analyze();
         
         Set<String> diagnostics = new HashSet<String>();
-        
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
+        collectErrors(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:44-49:compiler.err.cant.resolve.location", "/Use.java:64-77:compiler.err.type.error")), diagnostics);
     }
@@ -350,7 +327,10 @@ public class AttrTest extends TestCase {
         final JavacTaskImpl ct = (JavacTaskImpl)tool.getTask(null, null, dc, global.Utils.asParameters("-source", version, "-Xjcov"), null, Arrays.asList(new MyFileObject(code)));
         ct.analyze();
 
-        assertEquals(dc.getDiagnostics().toString(), 0, dc.getDiagnostics().size());
+        Set<String> diagnostics = new HashSet<String>();
+        collectErrors(dc, diagnostics);
+
+        assertEquals(dc.getDiagnostics().toString(), 0, diagnostics.size());
     }
 
     public void testLambda2() throws IOException {
@@ -364,7 +344,10 @@ public class AttrTest extends TestCase {
         final JavacTaskImpl ct = (JavacTaskImpl)tool.getTask(null, null, dc, global.Utils.asParameters("-source", version, "-Xjcov"), null, Arrays.asList(new MyFileObject(code)));
         ct.analyze();
 
-        assertEquals(dc.getDiagnostics().toString(), 0, dc.getDiagnostics().size());
+        Set<String> diagnostics = new HashSet<String>();
+        collectErrors(dc, diagnostics);
+
+        assertEquals(dc.getDiagnostics().toString(), 0, diagnostics.size());
     }
     
     public void testNonVoidReturnType() throws IOException {
@@ -378,7 +361,10 @@ public class AttrTest extends TestCase {
         final JavacTaskImpl ct = (JavacTaskImpl)tool.getTask(null, null, dc, global.Utils.asParameters("-source", version, "-Xjcov"), null, Arrays.asList(new MyFileObject(code)));
         ct.analyze();
 
-        assertEquals(dc.getDiagnostics().toString(), 0, dc.getDiagnostics().size());
+        Set<String> diagnostics = new HashSet<String>();
+        collectErrors(dc, diagnostics);
+
+        assertEquals(dc.getDiagnostics().toString(), 0, diagnostics.size());
     }
     
 //    @Ignore

--- a/make/langtools/netbeans/nb-javac/test/com/sun/tools/javac/comp/AttrTest.java
+++ b/make/langtools/netbeans/nb-javac/test/com/sun/tools/javac/comp/AttrTest.java
@@ -33,11 +33,13 @@ import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import com.sun.tools.javac.api.JavacTaskImpl;
+import global.Utils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -135,20 +137,11 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:64-72:compiler.err.type.error")), diagnostics);
     }
 
-    private void collectErrors(DiagnosticCollector<JavaFileObject> dc, Set<String> diagnostics) {
-        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
-            if (d.getSource() == null) {
-                continue;
-            }
-            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
-        }
-    }
-    
     public void testErrorReturnType2() throws IOException {
         final String version = System.getProperty("java.vm.specification.version"); //NOI18N
         final JavaCompiler tool = ToolProvider.getSystemJavaCompiler();
@@ -163,7 +156,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:68-68:compiler.err.expected")), diagnostics);
     }
@@ -182,7 +175,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:64-73:compiler.err.cant.resolve.location.args")), diagnostics);
     }
@@ -201,7 +194,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:90-94:compiler.err.type.error")), diagnostics);
     }
@@ -219,7 +212,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.<String>asList("/Use.java:47-52:compiler.err.cant.resolve.location")), diagnostics);
     }
@@ -238,7 +231,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:64-71:compiler.err.type.error")), diagnostics);
     }
@@ -257,7 +250,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:47-52:compiler.err.cant.resolve.location", "/Use.java:64-73:compiler.err.cant.resolve.location")), diagnostics);
     }
@@ -275,7 +268,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:64-69:compiler.err.cant.resolve.location")), diagnostics);
     }
@@ -293,7 +286,7 @@ public class AttrTest extends TestCase {
         
         Set<String> diagnostics = new HashSet<String>();
         
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/Use.java:93-104:compiler.err.cant.apply.diamond.1")), diagnostics);
     }
@@ -311,7 +304,7 @@ public class AttrTest extends TestCase {
         ct.analyze();
         
         Set<String> diagnostics = new HashSet<String>();
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
         
         assertEquals(new HashSet<String>(Arrays.asList("/API.java:44-49:compiler.err.cant.resolve.location", "/Use.java:64-77:compiler.err.type.error")), diagnostics);
     }
@@ -328,7 +321,7 @@ public class AttrTest extends TestCase {
         ct.analyze();
 
         Set<String> diagnostics = new HashSet<String>();
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
 
         assertEquals(dc.getDiagnostics().toString(), 0, diagnostics.size());
     }
@@ -345,7 +338,7 @@ public class AttrTest extends TestCase {
         ct.analyze();
 
         Set<String> diagnostics = new HashSet<String>();
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
 
         assertEquals(dc.getDiagnostics().toString(), 0, diagnostics.size());
     }
@@ -362,7 +355,7 @@ public class AttrTest extends TestCase {
         ct.analyze();
 
         Set<String> diagnostics = new HashSet<String>();
-        collectErrors(dc, diagnostics);
+        Utils.collectErrorsText(dc, diagnostics);
 
         assertEquals(dc.getDiagnostics().toString(), 0, diagnostics.size());
     }

--- a/make/langtools/netbeans/nb-javac/test/global/AP208917Test.java
+++ b/make/langtools/netbeans/nb-javac/test/global/AP208917Test.java
@@ -75,7 +75,7 @@ public class AP208917Test extends AbstractProcessor {
 
         DiagnosticCollector<JavaFileObject> diagnostic = new DiagnosticCollector<JavaFileObject>();
         List<String> options = new LinkedList<String>();
-        options.addAll(global.Utils.asParameters("-source", "1.8", "-classpath", System.getProperty("java.class.path")));
+        options.addAll(global.Utils.asParameters("--release", "8", "-classpath", System.getProperty("java.class.path")));
         options.addAll(Arrays.asList("-processor", AP208917Test.class.getName()));
         JavacTask ct = (JavacTask)tool.getTask(null, null, diagnostic, options, null, Arrays.asList(new MyFileObject("class Test {}")));
         ct.analyze();

--- a/make/langtools/netbeans/nb-javac/test/global/Utils.java
+++ b/make/langtools/netbeans/nb-javac/test/global/Utils.java
@@ -26,7 +26,11 @@ package global;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
 
 public class Utils {
     private Utils() {
@@ -40,6 +44,25 @@ public class Utils {
             arr.add(bootPath);
         }
         arr.addAll(Arrays.asList(params));
+        return arr;
+    }
+
+    public static void collectErrorsText(DiagnosticCollector<JavaFileObject> dc, Collection<String> diagnostics) {
+        for (Diagnostic<? extends JavaFileObject> d : dc.getDiagnostics()) {
+            if (d.getSource() == null) {
+                continue;
+            }
+            diagnostics.add(d.getSource().getName() + ":" + d.getStartPosition() + "-" + d.getEndPosition() + ":" + d.getCode());
+        }
+    }
+
+    public static Collection<Diagnostic<? extends JavaFileObject>> filterErrors(Collection<Diagnostic<? extends JavaFileObject>> diagnostics) {
+        List<Diagnostic<? extends JavaFileObject>> arr = new ArrayList<>();
+        for (Diagnostic<? extends JavaFileObject> d : diagnostics) {
+            if (d.getKind() == Diagnostic.Kind.ERROR) {
+                arr.add(d);
+            }
+        }
         return arr;
     }
 }


### PR DESCRIPTION
Currently one can only run the nb-javac own tests on JDK8. This PR tries to change it by running them also on JDK-17. The biggest problem was with missing `sun.boot.class.path` property, but that one is fixed by 4cee18550fee6331a582c9eaf648fc91b1f80107 - the rest has been fixed in subsequent commits.