### PR TITLE
Modified to fix ToolProvider.getSystemJavaCompiler throwing ServiceConfigurationErrors.

### DIFF
--- a/make/langtools/netbeans/nb-javac/src/META-INF/upgrade/nbjavac.hint
+++ b/make/langtools/netbeans/nb-javac/src/META-INF/upgrade/nbjavac.hint
@@ -193,7 +193,7 @@ $class.cast(((java.util.function.Supplier<Object>) () -> {
        Object v;
        try {
             v = javax.tools.ToolProvider.getSystemTool($class, $module, $name);
-        } catch (LinkageError err) {
+        } catch (Error err) {
             v = null;
         }
        if (v == null) {


### PR DESCRIPTION
Modified to fix ToolProvider.getSystemJavaCompiler throwing ServiceConfigurationErrors.