### PR TITLE
switched to jdk18u repo and jdk-18.0.1+10 tag.

### DIFF
--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,6 +1,6 @@
 
 jdk.git.url=https://github.com/openjdk/jdk18u
-jdk.git.commit=jdk-18.0.1+0
+jdk.git.commit=jdk-18.0.1+10
 nb-javac-ver=${jdk.git.commit}
 
 debug.modulepath=\

--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,6 +1,6 @@
 
-jdk.git.url=https://github.com/openjdk/jdk
-jdk.git.commit=jdk-18+36
+jdk.git.url=https://github.com/openjdk/jdk18u
+jdk.git.commit=jdk-18.0.1+0
 nb-javac-ver=${jdk.git.commit}
 
 debug.modulepath=\


### PR DESCRIPTION
18.0.1 has just been released. I updated the properties file to point at the latest release.

It builds and the test `nb-javac test` was green too - haven't done any other testing.

I haven't looked at the release notes yet, but .1 updates usually include many fixes.