### PR TITLE
upgrade javac dependency to jdk-19+36 (Java 19 GA).

### DIFF
--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,5 +1,5 @@
 jdk.git.url=https://github.com/openjdk/jdk19
-jdk.git.commit=jdk-19+33
+jdk.git.commit=jdk-19+36
 nb-javac-ver=${jdk.git.commit}
 
 debug.modulepath=\


### PR DESCRIPTION
Would be good to ship NB 16 with a GA version of javac.

I ran rudimentary tests with build 36 locally and everything appeared to be working, I did not run the full NB test suite.

There might be another opportunity to upgrade to nb-javac based on 19.0.1 during the RC phase of NB 16 in a few weeks.