### PR TITLE
Upgrade to jdk-22.0.1+8

### DIFF
--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,5 +1,5 @@
-jdk.git.url=https://github.com/openjdk/jdk22
-jdk.git.commit=jdk-22+33
+jdk.git.url=https://github.com/openjdk/jdk22u
+jdk.git.commit=jdk-22.0.1+8
 nb-javac-ver=${jdk.git.commit}
 #nb-javac-ver=jdk-21u
 


### PR DESCRIPTION
switches to 22u and moves the tag to 22.0.1.

`would fix` https://github.com/apache/netbeans/issues/6826 due to backport of https://bugs.openjdk.org/browse/JDK-8322159

I haven't looked at any other changes which happened between `+33` and `.1` - there might be more goodies.

This seems to build and run fine (had to manually clean lib and jdk of my checkout), we could run nb CI against a staged nb-javac.