### PR TITLE
Update to JDK 23 build 35.

### DIFF
--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,5 +1,5 @@
 jdk.git.url=https://github.com/openjdk/jdk
-jdk.git.commit=jdk-23+30
+jdk.git.commit=jdk-23+35
 nb-javac-ver=${jdk.git.commit}
 
 debug.modulepath=\


### PR DESCRIPTION
contains JDK-8336705, JDK-8336250 and JDK-8335926.

[changes](https://bugs.openjdk.org/issues/?jql=project%20%3D%20JDK%20AND%20status%20in%20(Resolved%2C%20Integrated%2C%20Completed)%20AND%20fixVersion%20in%20(23.0.1%2C%20%2223%22%2C%2023.0.2)%20AND%20component%20%3D%20tools%20AND%20%22Resolved%20In%20Build%22%20in%20(%22b31%22%2C%20%22b32%22%2C%20%22b33%22%2C%20%22b34%22%20%2C%20%22b35%22)%20AND%20Subcomponent%20in%20(javac%2C%20javac%2C%20javac%2C%20javac))

cc @JaroslavTulach @jtulach @dbalek @lahodaj