### PR TITLE
Update to JDK 23.0.1 (ga).

### DIFF
--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,5 +1,5 @@
-jdk.git.url=https://github.com/openjdk/jdk
-jdk.git.commit=jdk-23+35
+jdk.git.url=https://github.com/openjdk/jdk23u
+jdk.git.commit=jdk-23.0.1-ga
 nb-javac-ver=${jdk.git.commit}
 
 debug.modulepath=\


### PR DESCRIPTION
 - contains some javac bugfixes (one P2)
 - examples: [JDK-8337927](https://bugs.openjdk.org/browse/JDK-8337927) or [JDK-8336138](https://bugs.openjdk.org/browse/JDK-8336138)
 
 list of all update 1 fixes if used the filter right: [23.0.1 javac changes](https://bugs.openjdk.org/browse/JDK-8337927?jql=project%20%3D%20JDK%20AND%20status%20in%20(Resolved%2C%20Integrated%2C%20Completed)%20AND%20fixVersion%20%3D%2023.0.1%20AND%20component%20%3D%20tools%20AND%20Subcomponent%20in%20(javac%2C%20javac%2C%20javac%2C%20javac))
 
I can't check build 36 since it requires an account to filter by build

@jtulach @dbalek @lahodaj  friendly ping :)