### PR TITLE
Restore line numbers in stack traces.

### DIFF
--- a/make/langtools/netbeans/nb-javac/build.xml
+++ b/make/langtools/netbeans/nb-javac/build.xml
@@ -166,6 +166,11 @@
             <arg value="${src.dir}/java.compiler/share/classes"/>
             <arg value="${src.dir}/jdk.compiler/share/classes"/>
         </java>
+        <exec failonerror="true" executable="patch" dir="${src.dir}">
+            <arg value="-p1"/>
+            <arg value="-i"/>
+            <arg value="${src.dir}/../temporary-patches/unnamed-workaround"/>
+        </exec>
         <echo file="${src.dir}/jackpot-done">Jackpot done!</echo>
     </target>
 
@@ -214,8 +219,7 @@
                     <arg value="-jar"/>
                     <arg value="${tools.dir}/compiler.jar"/>
                     <arg line="${javac.compilerargs}"/>
-                    <arg value="-g:lines"/>
-                    <arg value="--enable-preview"/>
+                    <arg value="-g"/>
                     <arg value="-encoding"/>
                     <arg value="UTF-8"/>
                     <arg value="-cp"/>

--- a/temporary-patches/unnamed-workaround
+++ b/temporary-patches/unnamed-workaround
@@ -1,0 +1,66 @@
+diff --git a/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java b/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+index 560ccb9..dc30b7b 100644
+--- a/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
++++ b/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+@@ -1322,7 +1322,7 @@ public class Check {
+     private void warnOnExplicitStrictfp(JCTree tree) {
+         deferredLintHandler.push(tree);
+         try {
+-            deferredLintHandler.report(_ -> lint.logIfEnabled(tree.pos(), LintWarnings.Strictfp));
++            deferredLintHandler.report(__ -> lint.logIfEnabled(tree.pos(), LintWarnings.Strictfp));
+         } finally {
+             deferredLintHandler.pop();
+         }
+@@ -4127,7 +4127,7 @@ public class Check {
+             int opc = ((OperatorSymbol)operator).opcode;
+             if (opc == ByteCodes.idiv || opc == ByteCodes.imod
+                 || opc == ByteCodes.ldiv || opc == ByteCodes.lmod) {
+-                deferredLintHandler.report(_ -> lint.logIfEnabled(pos, LintWarnings.DivZero));
++                deferredLintHandler.report(__ -> lint.logIfEnabled(pos, LintWarnings.DivZero));
+             }
+         }
+     }
+@@ -4140,7 +4140,7 @@ public class Check {
+      */
+     void checkLossOfPrecision(final DiagnosticPosition pos, Type found, Type req) {
+         if (found.isNumeric() && req.isNumeric() && !types.isAssignable(found, req)) {
+-            deferredLintHandler.report(_ ->
++            deferredLintHandler.report(__ ->
+                 lint.logIfEnabled(pos, LintWarnings.PossibleLossOfPrecision(found, req)));
+         }
+     }
+@@ -4340,7 +4340,7 @@ public class Check {
+                             // Warning may be suppressed by
+                             // annotations; check again for being
+                             // enabled in the deferred context.
+-                            deferredLintHandler.report(_ ->
++                            deferredLintHandler.report(__ ->
+                                 lint.logIfEnabled(pos, LintWarnings.MissingExplicitCtor(c, pkg, modle)));
+                         } else {
+                             return;
+@@ -4675,7 +4675,7 @@ public class Check {
+ 
+     void checkModuleExists(final DiagnosticPosition pos, ModuleSymbol msym) {
+         if (msym.kind != MDL) {
+-            deferredLintHandler.report(_ ->
++            deferredLintHandler.report(__ ->
+                 lint.logIfEnabled(pos, LintWarnings.ModuleNotFound(msym)));
+         }
+     }
+@@ -4683,14 +4683,14 @@ public class Check {
+     void checkPackageExistsForOpens(final DiagnosticPosition pos, PackageSymbol packge) {
+         if (packge.members().isEmpty() &&
+             ((packge.flags() & Flags.HAS_RESOURCE) == 0)) {
+-            deferredLintHandler.report(_ ->
++            deferredLintHandler.report(__ ->
+                 lint.logIfEnabled(pos, LintWarnings.PackageEmptyOrNotFound(packge)));
+         }
+     }
+ 
+     void checkModuleRequires(final DiagnosticPosition pos, final RequiresDirective rd) {
+         if ((rd.module.flags() & Flags.AUTOMATIC_MODULE) != 0) {
+-            deferredLintHandler.report(_ -> {
++            deferredLintHandler.report(__ -> {
+                 if (rd.isTransitive() && lint.isEnabled(LintCategory.REQUIRES_TRANSITIVE_AUTOMATIC)) {
+                     log.warning(pos, LintWarnings.RequiresTransitiveAutomatic);
+                 } else {


### PR DESCRIPTION
Revert "Avoiding temporary patch."

This reverts commit 38bb91ecff9a1a1d1c8ae57524297f3ae19d3a2f.

problem description taken from https://github.com/apache/netbeans/pull/8572#issuecomment-3049946930:

the emitted classes in nb-javac do seem to have a line number table (`javap -v`), so on first glance everything is ok (but I haven't diffed the javap outputs).

stack trace looks like:
```
Caused: java.lang.AssertionError: Unexpected tree: (ERROR) ? (ERROR) > entry : (ERROR) with kind: CONDITIONAL_EXPRESSION within: (ERROR) ? (ERROR) > entry : (ERROR) with kind: CONDITIONAL_EXPRESSION
	at com.sun.tools.javac.util.Assert.error(Unknown Source)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.validateAnnotatedType(Unknown Source)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitVarDef(Unknown Source)
	at com.sun.tools.javac.tree.JCTree$JCVariableDecl.accept(Unknown Source)
	at com.sun.tools.javac.tree.TreeScanner.scan(Unknown Source)
	at com.sun.tools.javac.tree.TreeScanner.scan(Unknown Source)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitMethodDef(Unknown Source)
	at com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(Unknown Source)
	at com.sun.tools.javac.tree.TreeScanner.scan(Unknown Source)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitClassDef(Unknown Source)
	at com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(Unknown Source)
	at com.sun.tools.javac.comp.Attr.validateTypeAnnotations(Unknown Source)
```
building nb-javac without passing `--enable-preview` to frgaal does seem to work:
```
Caused: java.lang.AssertionError: Unexpected tree: (ERROR) ? (ERROR) > entry : (ERROR) with kind: CONDITIONAL_EXPRESSION within: (ERROR) ? (ERROR) > entry : (ERROR) with kind: CONDITIONAL_EXPRESSION
	at com.sun.tools.javac.util.Assert.error(Assert.java:162)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.validateAnnotatedType(Attr.java:5937)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitVarDef(Attr.java:5776)
	at com.sun.tools.javac.tree.JCTree$JCVariableDecl.accept(JCTree.java:1066)
	at com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:50)
	at com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:58)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitMethodDef(Attr.java:5766)
	at com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:960)
	at com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:50)
	at com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitClassDef(Attr.java:5829)
	at com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:859)
	at com.sun.tools.javac.comp.Attr.validateTypeAnnotations(Attr.java:5726)
```
other curiosity:

 - setting `-g --enable-preview` breaks the bytecode?
```
    [junit] java.lang.ClassFormatError: Illegal field name "" in class com/sun/tools/javac/comp/Check
    [junit] 	at com.sun.tools.javac.comp.Modules.<init>(Modules.java:195)
    [junit] 	at com.sun.tools.javac.comp.Modules.instance(Modules.java:183)
```
 - setting `-g:lines --enable-preview` produces traces without lines as shown above
 - setting `-g` does appear to work, and was the config we ran with so far


