### PR TITLE
update to 25 build 31

### DIFF
--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,5 +1,5 @@
 jdk.git.url=https://github.com/openjdk/jdk
-jdk.git.commit=jdk-25+29
+jdk.git.commit=jdk-25+31
 nb-javac-ver=${jdk.git.commit}
 
 debug.modulepath=\


### PR DESCRIPTION
3 javac fixes since b29 ([diff](https://github.com/openjdk/jdk/compare/jdk-25%2B29...jdk-25%2B31))

I believe two of them were discovered during the NB upgrade PR. (thanks to @lahodaj for fixing them so quickly)

@jtulach would be good to have a nb-javac 25 release soon, since it is late in the release cycle and nothing tests on javac 25 so far, the upgrade PR stages a custom build from my raspi atm. 

I think line numbers https://github.com/JaroslavTulach/nb-javac/pull/32 would be also a requirement otherwise we can't interpret user logs. (beside it being a red flag for potentially more things being broken)