### PR TITLE
fix: make nb-javac runnable inside Eclipse

### DIFF
--- a/make/langtools/netbeans/nb-javac/src/nbjavac/VMWrapper.java
+++ b/make/langtools/netbeans/nb-javac/src/nbjavac/VMWrapper.java
@@ -30,6 +30,7 @@ import java.lang.ref.SoftReference;
 import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
@@ -74,8 +75,7 @@ public class VMWrapper {
                 loader = ClassLoader.getSystemClassLoader();
             }
             Enumeration<URL> en = loader.getResources("META-INF/services/com.sun.tools.javac.platform.PlatformProvider");
-            URL res = en.hasMoreElements() ? en.nextElement() : null;
-            if (res == null) {
+            if (!en.hasMoreElements()) {
                 //runnning inside a JDK image, try to look for lib/ct.sym:
                 String javaHome = System.getProperty("java.home");
                 Path file = Paths.get(javaHome);
@@ -87,10 +87,7 @@ public class VMWrapper {
                 }
                 return FileSystems.newFileSystem(file, (ClassLoader)null).getRootDirectories().iterator().next();
             }
-            if (!res.getProtocol().equals("jar")) {
-                res = en.hasMoreElements() ? en.nextElement() : null;
-            }
-            URL jar = ((JarURLConnection)res.openConnection()).getJarFileURL();
+            URL jar = getJarUrl(en);
             Path path = Paths.get(jar.toURI());
             FileSystem fs = FileSystems.newFileSystem(path, (ClassLoader) null);
             Path ctSym = fs.getPath("META-INF", "ct.sym");
@@ -99,6 +96,38 @@ public class VMWrapper {
         } catch (IOException | URISyntaxException ex) {
             throw new IllegalStateException(ex);
         }
+    }
+
+    private static URL getJarUrl(Enumeration<URL> resources) throws IOException {
+        while (resources.hasMoreElements()) {
+            URL res = resources.nextElement();
+            if ("jar".equals(res.getProtocol())) {
+                return ((JarURLConnection)res.openConnection()).getJarFileURL();
+            } else if (res.getProtocol().equals("bundleresource")) {
+                // running inside Eclipse,
+                URLConnection conn = res.openConnection();
+                if (!"BundleURLConnection".equals(conn.getClass().getSimpleName())){
+                    continue;
+                }
+                // use reflection to call `public URL getLocalURL()` if it exists,
+                // as it converts the URL to a common local URL protocol (i.e file: or jar: protocol)
+                try {
+                    URL localUrl = (URL) conn.getClass().getMethod("getLocalURL").invoke(conn);
+                    if (localUrl == null) {
+                        continue;
+                    }
+                    if ("file".equals(localUrl.getProtocol())) {
+                        return localUrl;
+                    }
+                    if ("jar".equals(localUrl.getProtocol())) {
+                        return ((JarURLConnection) localUrl.openConnection()).getJarFileURL();
+                    }
+                } catch (ReflectiveOperationException ex) {
+                    // ignore and continue
+                }
+            }
+        }
+        throw new IllegalStateException("Cannot find jar URL for ct.sym");
     }
 
     public static DirectoryStream<Path> newDirectoryStream(Path dir) throws IOException {


### PR DESCRIPTION
I've been trying to run the nb-javac inside an Eclipse-based IDE, and had to patch VMWrapper.java to make it work
