### PR TITLE
Test building netbeans master

### DIFF
--- a/.github/workflows/netbeans.yml
+++ b/.github/workflows/netbeans.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
             git clone https://github.com/apache/netbeans
             cd netbeans
-            git checkout master
+            git checkout 30-rc2
       - name: Build NetBeans with latest nb-javac
         run: JAVA_HOME=`cat jdk21` ant -f netbeans build -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
       - name: Setup Xvfb

--- a/.github/workflows/netbeans.yml
+++ b/.github/workflows/netbeans.yml
@@ -37,12 +37,12 @@ jobs:
         run: |
             git clone https://github.com/apache/netbeans
             cd netbeans
-            git checkout 0a84604d51f9e8b560c060b8e26cdb3ee3141804
+            git checkout master
       - name: Build NetBeans with latest nb-javac
-        run: JAVA_HOME=`cat jdk11` ant -f netbeans build -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
+        run: JAVA_HOME=`cat jdk21` ant -f netbeans build -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
       - name: Setup Xvfb
         run: |
           echo "DISPLAY=:99.0" >> $GITHUB_ENV
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
       - name: Test with Commit Validation
-        run: JAVA_HOME=`cat jdk11` ant -f netbeans commit-validation -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
+        run: JAVA_HOME=`cat jdk21` ant -f netbeans commit-validation -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar


### PR DESCRIPTION
Instead of building a selected branch from the past, build the current master of netbeans. Building old versions of NetBeans caused problems not to be noticed.