### PR TITLE
1:1 semantics with `DirectModuleWrapper` over `java.lang.Module`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on: [push]
 jobs: 
   linux: 
     name: "Backported nb-javac"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8

--- a/.github/workflows/netbeans.yml
+++ b/.github/workflows/netbeans.yml
@@ -6,9 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  linux:
+  build:
     name: "NetBeans on nb-javac"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # 7d33005615b3c744564f3d38ab9ef14bf8c3ec44 (tag: 18-rc4, tag: 18, origin/release180, apache/release180
+        tag: [ '7d33005615b3c744564f3d38ab9ef14bf8c3ec44' ]
+        os: [ ubuntu-22.04 ]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8
@@ -40,7 +47,7 @@ jobs:
         run: |
             git clone https://github.com/apache/netbeans
             cd netbeans
-            git checkout 0a84604d51f9e8b560c060b8e26cdb3ee3141804
+            git checkout ${{ matrix.tag }}
       - name: Build NetBeans with latest nb-javac
         run: JAVA_HOME=`cat jdk11` ant -f netbeans build -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
       - name: Setup Xvfb

--- a/.github/workflows/netbeans.yml
+++ b/.github/workflows/netbeans.yml
@@ -15,11 +15,14 @@ jobs:
         # git merge-base 18 0a84604d51 => bf19d75c7df884092123d2d6bfe61eef7fc4cd73
         # git merge-base 19 0a84604d51 => 0a84604d51f9e8b560c060b8e26cdb3ee3141804
         # e.g. 0a84604d51 is a commit somewhere between NetBeans 18 and 19
-        tag: [ '0a84604d51' ]
+        #
+        # 46c1feab2c => (tag: 30-rc2, origin/release300)
+        tag: [ '0a84604d51', '46c1feab2c' ]
         os: [ ubuntu-24.04 ]
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -27,13 +30,23 @@ jobs:
             java-version: 8
       - name: Record JDK8
         run: echo "$JAVA_HOME" | tee jdk8
+
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
             distribution: 'zulu'
             java-version: 11
       - name: Record JDK11
-        run: echo "$JAVA_HOME" | tee jdk11
+        run: echo "$JAVA_HOME" | tee jdk11 | tee jdk-0a84604d51
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v2
+        with:
+            distribution: 'zulu'
+            java-version: 21
+      - name: Record JDK21
+        run: echo "$JAVA_HOME" | tee jdk21 | tee jdk-46c1feab2c
+
       - name: Set up JDK 25
         uses: actions/setup-java@v2
         with:
@@ -41,20 +54,25 @@ jobs:
             java-version: 25.0.0
       - name: Record JDK25
         run: echo "$JAVA_HOME" | tee jdk25
+
       - name: Jackpot on JDK25
         run: ant -f make/langtools/netbeans/nb-javac clean jackpot generate-files
       - name: Finish Build on JDK8
         run: JAVA_HOME=`cat jdk8` ant -f make/langtools/netbeans/nb-javac jar
+
       - name: Check NetBeans out
         run: |
             git clone https://github.com/apache/netbeans
             cd netbeans
             git checkout ${{ matrix.tag }}
+
       - name: Build NetBeans with latest nb-javac
-        run: JAVA_HOME=`cat jdk11` ant -f netbeans build -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
+        run: JAVA_HOME=`cat jdk-${{ matrix.tag }}` ant -f netbeans build -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
+
       - name: Setup Xvfb
         run: |
           echo "DISPLAY=:99.0" >> $GITHUB_ENV
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
       - name: Test with Commit Validation
-        run: JAVA_HOME=`cat jdk11` ant -f netbeans commit-validation -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar
+        run: JAVA_HOME=`cat jdk-${{ matrix.tag }}` ant -f netbeans commit-validation -Dnbjavac.class.path=`pwd`/make/langtools/netbeans/nb-javac/dist/nb-javac-*.jar

--- a/.github/workflows/netbeans.yml
+++ b/.github/workflows/netbeans.yml
@@ -12,8 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 7d33005615b3c744564f3d38ab9ef14bf8c3ec44 (tag: 18-rc4, tag: 18, origin/release180, apache/release180
-        tag: [ '7d33005615b3c744564f3d38ab9ef14bf8c3ec44' ]
+        # git merge-base 18 0a84604d51 => bf19d75c7df884092123d2d6bfe61eef7fc4cd73
+        # git merge-base 19 0a84604d51 => 0a84604d51f9e8b560c060b8e26cdb3ee3141804
+        # e.g. 0a84604d51 is a commit somewhere between NetBeans 18 and 19
+        tag: [ '0a84604d51' ]
         os: [ ubuntu-24.04 ]
 
     steps:

--- a/.github/workflows/netbeans.yml
+++ b/.github/workflows/netbeans.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # 7d33005615b3c744564f3d38ab9ef14bf8c3ec44 (tag: 18-rc4, tag: 18, origin/release180, apache/release180
         tag: [ '7d33005615b3c744564f3d38ab9ef14bf8c3ec44' ]
-        os: [ ubuntu-22.04 ]
+        os: [ ubuntu-24.04 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/netbeans.yml
+++ b/.github/workflows/netbeans.yml
@@ -16,8 +16,8 @@ jobs:
         # git merge-base 19 0a84604d51 => 0a84604d51f9e8b560c060b8e26cdb3ee3141804
         # e.g. 0a84604d51 is a commit somewhere between NetBeans 18 and 19
         #
-        # 46c1feab2c => (tag: 30-rc2, origin/release300)
-        tag: [ '0a84604d51', '46c1feab2c' ]
+        # 1ca1c4856b => (close to release300 with #9383 fix)
+        tag: [ '0a84604d51', '1ca1c4856b' ]
         os: [ ubuntu-24.04 ]
 
     steps:

--- a/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapper.java
+++ b/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapper.java
@@ -24,64 +24,35 @@
  */
 package nbjavac;
 
-import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
+import java.util.function.BiFunction;
 
-public class ModuleWrapper {
-    private final Class<?> clazz;
-
-    private ModuleWrapper(Class<?> c) {
-        this.clazz = c;
+public abstract class ModuleWrapper {
+    private static final BiFunction<Class<?>, ClassLoader, ModuleWrapper> FACTORY;
+    static {
+        FACTORY = ModuleWrapperFallback.factory();
     }
 
     public static ModuleWrapper getModule(Class<?> clazz) {
-        return new ModuleWrapper(clazz);
+        return FACTORY.apply(clazz, null);
     }
 
     public static ModuleWrapper getUnnamedModule(ClassLoader loader) {
-        return new ModuleWrapper(null);
+        return FACTORY.apply(null, loader);
     }
 
-    public String getName() {
-        switch (clazz.getName()) {
-            case "jdk.javadoc.internal.api.JavadocTool": return "jdk.javadoc";
-            case "com.sun.tools.javac.api.JavacTool": return "jdk.compiler";
-            default: return "jdk.compiler"; //XXX
-        }
-    }
+    public abstract String getName();
+    public abstract boolean isNamed();
+    public abstract void addExports(String pack, ModuleWrapper to);
+    public abstract <S> void addUses(Class<S> service);
 
-    public boolean isNamed() {
-        return false;
-    }
-
-    public void addExports(String pack, ModuleWrapper to) {
-    }
-
-    public <S> void addUses(Class<S> service) {
-        if (this.clazz != null) {
-            ensureUses(this.clazz, service);
-        }
-        ensureUses(service);
-    }
 
     static void ensureUses(Class<?> clazz) {
         // ServiceLoaderWrapper.class.getModule().addUses(aClass);
         Class<?> thisClass = ServiceLoaderWrapper.class;
-        ensureUses(thisClass, clazz);
-    }
-
-    private static void ensureUses(Class<?> thisClass, Class<?> clazz) {
-        try {
-            final Class<?> Module = Class.forName("java.lang.Module");
-            final Method addUses = Module.getDeclaredMethod("addUses", Class.class);
-            final Method getModule = Class.class.getDeclaredMethod("getModule");
-            final Object thisClassModule = getModule.invoke(thisClass);
-            addUses.invoke(thisClassModule, clazz);
-        } catch (SecurityException | ReflectiveOperationException t) {
-            //ignore - might log?
-        }
+        ModuleWrapperFallback.ensureUses(thisClass, clazz);
     }
 
     public static class ModuleFinder {

--- a/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapper.java
+++ b/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapper.java
@@ -35,7 +35,7 @@ public abstract class ModuleWrapper {
         BiFunction<Class<?>, ClassLoader, ModuleWrapper> f;
         try {
             f = ModuleWrapperDirect.factory();
-        } catch (ClassNotFoundException ex) {
+        } catch (ReflectiveOperationException ex) {
             f = ModuleWrapperFallback.factory();
         }
         FACTORY = f;

--- a/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapper.java
+++ b/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapper.java
@@ -32,7 +32,13 @@ import java.util.function.BiFunction;
 public abstract class ModuleWrapper {
     private static final BiFunction<Class<?>, ClassLoader, ModuleWrapper> FACTORY;
     static {
-        FACTORY = ModuleWrapperFallback.factory();
+        BiFunction<Class<?>, ClassLoader, ModuleWrapper> f;
+        try {
+            f = ModuleWrapperDirect.factory();
+        } catch (ClassNotFoundException ex) {
+            f = ModuleWrapperFallback.factory();
+        }
+        FACTORY = f;
     }
 
     public static ModuleWrapper getModule(Class<?> clazz) {

--- a/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapperDirect.java
+++ b/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapperDirect.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package nbjavac;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+final class ModuleWrapperDirect extends ModuleWrapper {
+    /** instance of java.lang.Module */
+    private final Module module;
+
+    private ModuleWrapperDirect(Module module) {
+        this.module = module;
+    }
+
+
+    static BiFunction<Class<?>, ClassLoader, ModuleWrapper> factory() throws ClassNotFoundException {
+        Class<?> moduleClass = Class.forName("java.lang.Module");
+        Objects.requireNonNull(moduleClass);
+        return (clazz, loader) -> {
+            if (clazz != null) {
+                return new ModuleWrapperDirect(clazz.getModule());
+            } else {
+                return new ModuleWrapperDirect(loader.getUnnamedModule());
+            }
+        };
+    }
+
+    @Override
+    public String getName() {
+        return module.getName();
+    }
+
+    @Override
+    public boolean isNamed() {
+        return module.isNamed();
+    }
+
+    @Override
+    public void addExports(String pack, ModuleWrapper to) {
+        Module toModule = ((ModuleWrapperDirect)to).module;
+        module.addExports(pack, toModule);
+    }
+
+    @Override
+    public <S> void addUses(Class<S> service) {
+        module.addUses(service);
+    }
+}

--- a/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapperDirect.java
+++ b/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapperDirect.java
@@ -24,48 +24,86 @@
  */
 package nbjavac;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
 final class ModuleWrapperDirect extends ModuleWrapper {
-    /** instance of java.lang.Module */
-    private final Module module;
+    // methods for reflective access to JDK9+ API
+    private static Method getModuleForClass;
+    private static Method getUnnamedModuleForLoader;
+    private static Method getNameForModule;
+    private static Method isNamedForModule;
+    private static Method addUsesForModule;
+    private static Method addExportsForModule;
 
-    private ModuleWrapperDirect(Module module) {
+    /** instance of java.lang.Module */
+    private final Object module;
+
+    private ModuleWrapperDirect(Object module) {
         this.module = module;
     }
 
 
-    static BiFunction<Class<?>, ClassLoader, ModuleWrapper> factory() throws ClassNotFoundException {
+    static BiFunction<Class<?>, ClassLoader, ModuleWrapper> factory() throws ReflectiveOperationException {
         Class<?> moduleClass = Class.forName("java.lang.Module");
         Objects.requireNonNull(moduleClass);
+        getModuleForClass = Class.class.getMethod("getModule");
+        getUnnamedModuleForLoader = ClassLoader.class.getMethod("getUnnamedModule");
+        getNameForModule = moduleClass.getMethod("getName");
+        isNamedForModule = moduleClass.getMethod("isNamed");
+        addUsesForModule = moduleClass.getMethod("addUses", Class.class);
+        addExportsForModule = moduleClass.getMethod("addExports", String.class, moduleClass);
         return (clazz, loader) -> {
-            if (clazz != null) {
-                return new ModuleWrapperDirect(clazz.getModule());
-            } else {
-                return new ModuleWrapperDirect(loader.getUnnamedModule());
+            try {
+                Object module;
+                if (clazz != null) {
+                    module = getModuleForClass.invoke(clazz);
+                } else {
+                    module = getUnnamedModuleForLoader.invoke(loader);
+                }
+                return new ModuleWrapperDirect(module);
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException(ex);
             }
         };
     }
 
     @Override
     public String getName() {
-        return module.getName();
+        try {
+            return (String) getNameForModule.invoke(module);
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     @Override
     public boolean isNamed() {
-        return module.isNamed();
+        try {
+            return (Boolean) isNamedForModule.invoke(module);
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     @Override
     public void addExports(String pack, ModuleWrapper to) {
-        Module toModule = ((ModuleWrapperDirect)to).module;
-        module.addExports(pack, toModule);
+        Object toModule = ((ModuleWrapperDirect)to).module;
+        try {
+            addExportsForModule.invoke(module, pack, toModule);
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     @Override
     public <S> void addUses(Class<S> service) {
-        module.addUses(service);
+        try {
+            addUsesForModule.invoke(module, service);
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 }

--- a/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapperFallback.java
+++ b/make/langtools/netbeans/nb-javac/src/nbjavac/ModuleWrapperFallback.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package nbjavac;
+
+import java.lang.reflect.Method;
+import java.util.ServiceLoader;
+import java.util.function.BiFunction;
+
+final class ModuleWrapperFallback extends ModuleWrapper {
+    private final Class<?> clazz;
+
+    private ModuleWrapperFallback(Class<?> c) {
+        this.clazz = c;
+    }
+
+    static BiFunction<Class<?>, ClassLoader, ModuleWrapper> factory() {
+        return (clazz, loaer) -> {
+            return new ModuleWrapperFallback(clazz);
+        };
+    }
+
+    @Override
+    public String getName() {
+        switch (clazz.getName()) {
+            case "jdk.javadoc.internal.api.JavadocTool": return "jdk.javadoc";
+            case "com.sun.tools.javac.api.JavacTool": return "jdk.compiler";
+            default: return "jdk.compiler"; //XXX
+        }
+    }
+
+    @Override
+    public boolean isNamed() {
+        return false;
+    }
+
+    @Override
+    public void addExports(String pack, ModuleWrapper to) {
+    }
+
+    @Override
+    public <S> void addUses(Class<S> service) {
+        if (this.clazz != null) {
+            ensureUses(this.clazz, service);
+        }
+        ensureUses(ServiceLoader.class, service);
+    }
+
+    static void ensureUses(Class<?> thisClass, Class<?> clazz) {
+        try {
+            final Class<?> Module = Class.forName("java.lang.Module");
+            final Method addUses = Module.getDeclaredMethod("addUses", Class.class);
+            final Method getModule = Class.class.getDeclaredMethod("getModule");
+            final Object thisClassModule = getModule.invoke(thisClass);
+            addUses.invoke(thisClassModule, clazz);
+        } catch (SecurityException | ReflectiveOperationException t) {
+            //ignore - might log?
+        }
+    }
+}

--- a/make/langtools/netbeans/nb-javac/test/global/AnnotationProcessingTest.java
+++ b/make/langtools/netbeans/nb-javac/test/global/AnnotationProcessingTest.java
@@ -31,9 +31,13 @@ import com.sun.tools.javac.api.JavacTaskImpl;
 import global.ap1.AP;
 import global.ap1.ClassBasedAP;
 import global.ap1.ErrorProducingAP;
+import global.ap1.ModuleCheckingAP;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
@@ -232,6 +236,33 @@ public class AnnotationProcessingTest extends TestCase {
 
         assertTrue(new File(sourceOutput, "java.lang.String.txt").canRead());
         
+        //intentionally not deleting thwn the test fails to simply diagnostic
+        delete(sourceOutput);
+    }
+    
+    public void testModuleElementNamesMatcheModuleNames() throws IOException {
+        File sourceOutput = File.createTempFile("ModuleNames", "");
+        
+        sourceOutput.delete();
+        assertTrue(sourceOutput.mkdirs());
+
+        final String version = System.getProperty("java.vm.specification.version"); //NOI18N
+        URL myself = AnnotationProcessingTest.class.getProtectionDomain().getCodeSource().getLocation();
+        
+        Main.compile(Utils.asParameters(
+            "-source", version,
+            "-target", version,
+            "-classpath", myself.toExternalForm(),
+            "-processor", ModuleCheckingAP.class.getName(),
+            "-s", sourceOutput.getAbsolutePath(),
+            "java.lang.String"
+        ).toArray(new String[0]));
+        
+        final File file = new File(sourceOutput, "ModuleNames.txt");
+        assertTrue(file.canRead());
+        try (BufferedReader r = new BufferedReader(new FileReader(file))) {
+            assertEquals("Generated file " + file + " contains", "java.lang.SuppressWarnings", r.readLine());
+        }
         //intentionally not deleting thwn the test fails to simply diagnostic
         delete(sourceOutput);
     }

--- a/make/langtools/netbeans/nb-javac/test/global/ap1/ModuleCheckingAP.java
+++ b/make/langtools/netbeans/nb-javac/test/global/ap1/ModuleCheckingAP.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2003-2004 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Sun designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Sun in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ */
+
+package global.ap1;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.QualifiedNameable;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import nbjavac.ModuleWrapper;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedAnnotationTypes("*")
+public final class ModuleCheckingAP extends AbstractProcessor {
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        try (
+            Writer w = processingEnv.getFiler().createResource(StandardLocation.SOURCE_OUTPUT, "", "ModuleNames.txt").openWriter();
+        ) {
+            assertModules(w, SuppressWarnings.class);
+        } catch (ReflectiveOperationException | IOException ex) {
+            ex.printStackTrace();
+        }
+        return false;
+    }
+
+    private void assertModules(Writer w, Class<?> clazz) throws IOException, ReflectiveOperationException {
+        QualifiedNameable e1, e2;
+        String moduleName;
+        try {
+            moduleName = moduleFor(clazz);
+            Assert.assertNotNull("Module for " + clazz + " found", moduleName);
+            // use real module names on JDK9+
+            e1 = moduleElementFor(clazz);
+            e2 = moduleElementViaWrapperFor(clazz);
+        } catch (NoSuchMethodException ex) {
+            // aproximations on JDK8...
+            moduleName = null;
+            e1 = moduleElementFor(clazz);
+            e2 = moduleElementViaWrapperFor(clazz);
+        }
+        assertEquals("Same module via different methods for " + clazz, e1, e2);
+        if (moduleName != null) {
+            assertEquals("Module name via element must match runtime name", moduleName, e1.getQualifiedName().toString());
+            assertEquals("ModuleWrapper name must much runtime name", moduleName, e2.getQualifiedName().toString());
+        }
+        // write the output
+        w.append(clazz.getName() + "\n");
+    }
+    
+    private static String moduleFor(Class<?> clazz) throws NoSuchMethodException {
+        try {
+            Method getModule = Class.class.getMethod("getModule");
+            Object module = getModule.invoke(clazz);
+            Method getName = module.getClass().getMethod("getName");
+            return (String) getName.invoke(module);
+        } catch (NoSuchMethodException ex) {
+            throw ex;
+        } catch (ClassCastException | ReflectiveOperationException ex) {
+            return ex.toString();
+        }
+    }
+
+    private QualifiedNameable moduleElementFor(Class<?> clazz) throws ReflectiveOperationException {
+        final Elements eu = processingEnv.getElementUtils();
+        TypeElement element = eu.getTypeElement(clazz.getName());
+        Method getModuleOf = eu.getClass().getMethod("getModuleOf", Element.class);
+        QualifiedNameable module = (QualifiedNameable) getModuleOf.invoke(eu, element);
+        return module;
+    }
+    
+    private QualifiedNameable moduleElementViaWrapperFor(Class<?> clazz) throws ReflectiveOperationException {
+        final Elements eu = processingEnv.getElementUtils();
+        ModuleWrapper module = ModuleWrapper.getModule(clazz);
+        Method getModuleElement = eu.getClass().getMethod("getModuleElement", CharSequence.class);
+        QualifiedNameable element = (QualifiedNameable) getModuleElement.invoke(eu, module.getName());
+        return element;
+    }
+}

--- a/make/langtools/netbeans/nb-javac/test/global/ap1/ModuleCheckingAP.java
+++ b/make/langtools/netbeans/nb-javac/test/global/ap1/ModuleCheckingAP.java
@@ -26,27 +26,20 @@
 package global.ap1;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
-import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import nbjavac.ModuleWrapper;
-import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
 
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("*")
@@ -69,7 +62,7 @@ public final class ModuleCheckingAP extends AbstractProcessor {
         String moduleName;
         try {
             moduleName = moduleFor(clazz);
-            Assert.assertNotNull("Module for " + clazz + " found", moduleName);
+            assertNotNull("Module for " + clazz + " found", moduleName);
             // use real module names on JDK9+
             e1 = moduleElementFor(clazz);
             e2 = moduleElementViaWrapperFor(clazz);
@@ -115,5 +108,24 @@ public final class ModuleCheckingAP extends AbstractProcessor {
         Method getModuleElement = eu.getClass().getMethod("getModuleElement", CharSequence.class);
         QualifiedNameable element = (QualifiedNameable) getModuleElement.invoke(eu, module.getName());
         return element;
+    }
+
+    private static void assertEquals(String msg, Object expected, Object actual) {
+        if (expected == null) {
+            if (actual == null) {
+                return;
+            }
+        } else {
+            if (expected.equals(actual)) {
+                return;
+            }
+        }
+        throw new AssertionError(msg + " expecting: " + expected + " but got: " + actual);
+    }
+
+    private void assertNotNull(String msg, Object value) {
+        if (value == null) {
+            throw new AssertionError(msg);
+        }
     }
 }

--- a/make/langtools/netbeans/nb-javac/test/global/ap1/ModuleCheckingAP.java
+++ b/make/langtools/netbeans/nb-javac/test/global/ap1/ModuleCheckingAP.java
@@ -44,9 +44,14 @@ import nbjavac.ModuleWrapper;
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("*")
 public final class ModuleCheckingAP extends AbstractProcessor {
+    private boolean processed;
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (this.processed) {
+            return false;
+        }
+        this.processed = true;
         try (
             Writer w = processingEnv.getFiler().createResource(StandardLocation.SOURCE_OUTPUT, "", "ModuleNames.txt").openWriter();
         ) {
@@ -80,7 +85,7 @@ public final class ModuleCheckingAP extends AbstractProcessor {
         // write the output
         w.append(clazz.getName() + "\n");
     }
-    
+
     private static String moduleFor(Class<?> clazz) throws NoSuchMethodException {
         try {
             Method getModule = Class.class.getMethod("getModule");
@@ -101,7 +106,7 @@ public final class ModuleCheckingAP extends AbstractProcessor {
         QualifiedNameable module = (QualifiedNameable) getModuleOf.invoke(eu, element);
         return module;
     }
-    
+
     private QualifiedNameable moduleElementViaWrapperFor(Class<?> clazz) throws ReflectiveOperationException {
         final Elements eu = processingEnv.getElementUtils();
         ModuleWrapper module = ModuleWrapper.getModule(clazz);


### PR DESCRIPTION
- fixes #38 by:
   - creating a unit test - done in 686425a1fdd0e997546ccb40b08a8cc91d0efa95
   - running NetBeans check on recent bits 
      - inspired by @matthiasblaesing suggestions in #37
   - turning `ModuleWrapper` into abstract class
   - providing two implementations - direct and fallback
- checking that everything gets green