### PR TITLE
Updating to JDK 27b26.

### DIFF
--- a/make/langtools/netbeans/nb-javac/nbproject/project.properties
+++ b/make/langtools/netbeans/nb-javac/nbproject/project.properties
@@ -1,5 +1,5 @@
 jdk.git.url=https://github.com/openjdk/jdk
-jdk.git.commit=jdk-27+23
+jdk.git.commit=jdk-27+26
 nb-javac-ver=${jdk.git.commit}
 
 root=../../../..


### PR DESCRIPTION
This is a post-RDP1 build for OpenJDK 27. We can probably actually include this version in NetBeans.